### PR TITLE
Fix: Wallet list first open stuttering

### DIFF
--- a/app/src/main/java/me/juangoncalves/mentra/extensions/FragmentTransaction.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/extensions/FragmentTransaction.kt
@@ -1,25 +1,22 @@
 package me.juangoncalves.mentra.extensions
 
+import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
-import me.juangoncalves.mentra.R
 
-fun FragmentTransaction.hide(tag: String, manager: FragmentManager): FragmentTransaction = apply {
-    manager.findFragmentByTag(tag)?.let { fragment ->
-        hide(fragment)
-    }
-}
 
-fun FragmentTransaction.showExistingOrCreate(
+fun FragmentTransaction.show(
+    fragment: Fragment,
+    manager: FragmentManager,
     tag: String,
-    fragment: Lazy<Fragment>,
-    manager: FragmentManager
+    @IdRes fragmentContainerId: Int
 ): FragmentTransaction = apply {
     val existingInstance = manager.findFragmentByTag(tag)
     if (existingInstance != null) {
         show(existingInstance)
     } else {
-        add(R.id.fragmentContainer, fragment.value, tag)
+        add(fragmentContainerId, fragment, tag)
+        show(fragment)
     }
 }

--- a/app/src/main/java/me/juangoncalves/mentra/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/dashboard/DashboardActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.viewModels
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.observe
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import me.juangoncalves.mentra.R
 import me.juangoncalves.mentra.databinding.DashboardActivityBinding
 import me.juangoncalves.mentra.domain.models.Price
@@ -19,6 +20,7 @@ import me.juangoncalves.mentra.ui.wallet_list.WalletListFragment
 import kotlin.math.absoluteValue
 import kotlin.math.sign
 
+@ExperimentalCoroutinesApi
 @AndroidEntryPoint
 class DashboardActivity : FragmentActivity() {
 

--- a/app/src/main/java/me/juangoncalves/mentra/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/dashboard/DashboardActivity.kt
@@ -13,8 +13,7 @@ import me.juangoncalves.mentra.databinding.DashboardActivityBinding
 import me.juangoncalves.mentra.domain.models.Price
 import me.juangoncalves.mentra.extensions.asCurrency
 import me.juangoncalves.mentra.extensions.asPercentage
-import me.juangoncalves.mentra.extensions.hide
-import me.juangoncalves.mentra.extensions.showExistingOrCreate
+import me.juangoncalves.mentra.extensions.show
 import me.juangoncalves.mentra.ui.stats.StatsFragment
 import me.juangoncalves.mentra.ui.wallet_list.WalletListFragment
 import kotlin.math.absoluteValue
@@ -26,6 +25,9 @@ class DashboardActivity : FragmentActivity() {
     private val viewModel: DashboardViewModel by viewModels()
 
     private lateinit var binding: DashboardActivityBinding
+
+    private val statsFragment: StatsFragment = StatsFragment()
+    private val walletListFragment: WalletListFragment = WalletListFragment()
 
     companion object {
         const val WALLETS_FRAGMENT_TAG = "wallets_fragment"
@@ -100,12 +102,13 @@ class DashboardActivity : FragmentActivity() {
                 R.animator.fade_in, R.animator.fade_out,
                 R.animator.fade_in, R.animator.fade_out
             )
-            .showExistingOrCreate(
+            .show(
+                statsFragment,
+                supportFragmentManager,
                 STATS_FRAGMENT_TAG,
-                lazy { StatsFragment() },
-                supportFragmentManager
+                R.id.fragmentContainer
             )
-            .hide(WALLETS_FRAGMENT_TAG, supportFragmentManager)
+            .hide(walletListFragment)
             .commit()
 
         binding.navButton.setImageDrawable(getDrawable(R.drawable.ic_wallet))
@@ -118,12 +121,13 @@ class DashboardActivity : FragmentActivity() {
                 R.animator.fade_in, R.animator.fade_out,
                 R.animator.fade_in, R.animator.fade_out
             )
-            .showExistingOrCreate(
+            .show(
+                walletListFragment,
+                supportFragmentManager,
                 WALLETS_FRAGMENT_TAG,
-                lazy { WalletListFragment() },
-                supportFragmentManager
+                R.id.fragmentContainer
             )
-            .hide(STATS_FRAGMENT_TAG, supportFragmentManager)
+            .hide(statsFragment)
             .commit()
 
         binding.navButton.setImageDrawable(getDrawable(R.drawable.ic_chart))

--- a/app/src/main/java/me/juangoncalves/mentra/ui/wallet_creation/CoinAdapter.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/wallet_creation/CoinAdapter.kt
@@ -13,10 +13,14 @@ import me.juangoncalves.mentra.domain.models.Coin
 
 class CoinAdapter : RecyclerView.Adapter<CoinAdapter.ViewHolder>() {
 
-    private val differ: AsyncListDiffer<Coin> = AsyncListDiffer(this, CoinItemCallback())
+    var data: List<Coin>
+        get() = differ.currentList
+        set(value) = differ.submitList(value)
 
     var selectedCoin: Coin? = null
         private set
+
+    private val differ: AsyncListDiffer<Coin> = AsyncListDiffer(this, CoinItemCallback())
 
     override fun getItemCount() = differ.currentList.size
 
@@ -52,8 +56,6 @@ class CoinAdapter : RecyclerView.Adapter<CoinAdapter.ViewHolder>() {
             }
         }
     }
-
-    fun submitList(data: List<Coin>) = differ.submitList(data)
 
     inner class ViewHolder(val binding: CoinRecommendationItemBinding) :
         RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/me/juangoncalves/mentra/ui/wallet_creation/WalletCreationActivity.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/wallet_creation/WalletCreationActivity.kt
@@ -55,7 +55,7 @@ class WalletCreationActivity : AppCompatActivity() {
         showSnackbarOnFleetingErrors(viewModel, binding.root)
 
         viewModel.coins.observe(this) { coins ->
-            coinAdapter.submitList(coins)
+            coinAdapter.data = coins
         }
 
         viewModel.shouldScrollToStart.observe(this) {

--- a/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletAdapter.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletAdapter.kt
@@ -2,6 +2,7 @@ package me.juangoncalves.mentra.ui.wallet_list
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -10,16 +11,15 @@ import me.juangoncalves.mentra.databinding.WalletListItemBinding
 import me.juangoncalves.mentra.extensions.asCoinAmount
 import me.juangoncalves.mentra.extensions.asCurrency
 
-class WalletAdapter(data: List<DisplayWallet>) : RecyclerView.Adapter<WalletAdapter.ViewHolder>() {
+class WalletAdapter : RecyclerView.Adapter<WalletAdapter.ViewHolder>() {
 
-    var data: List<DisplayWallet> = data
-        set(value) {
-            val diffResult = DiffUtil.calculateDiff(WalletDiffCallback(field, value))
-            field = value
-            diffResult.dispatchUpdatesTo(this)
-        }
+    var data: List<DisplayWallet>
+        get() = differ.currentList
+        set(value) = differ.submitList(value)
 
-    override fun getItemCount() = data.size
+    private val differ: AsyncListDiffer<DisplayWallet> = AsyncListDiffer(this, WalletItemCallback())
+
+    override fun getItemCount() = differ.currentList.size
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = WalletListItemBinding.inflate(
@@ -31,7 +31,7 @@ class WalletAdapter(data: List<DisplayWallet>) : RecyclerView.Adapter<WalletAdap
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val displayWallet = data[position]
+        val displayWallet = differ.currentList[position]
         holder.binding.apply {
             coinNameTextView.text = displayWallet.wallet.coin.name
             coinAmountTextView.text = displayWallet.wallet.amount.asCoinAmount()
@@ -58,21 +58,13 @@ class WalletAdapter(data: List<DisplayWallet>) : RecyclerView.Adapter<WalletAdap
 
 }
 
-class WalletDiffCallback(
-    private val old: List<DisplayWallet>,
-    private val next: List<DisplayWallet>
-) : DiffUtil.Callback() {
 
-    override fun getOldListSize(): Int = old.size
-
-    override fun getNewListSize(): Int = next.size
-
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return old[oldItemPosition].wallet.id == next[newItemPosition].wallet.id
+class WalletItemCallback : DiffUtil.ItemCallback<DisplayWallet>() {
+    override fun areItemsTheSame(oldItem: DisplayWallet, newItem: DisplayWallet): Boolean {
+        return oldItem == newItem
     }
 
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return old[oldItemPosition] == next[newItemPosition]
+    override fun areContentsTheSame(oldItem: DisplayWallet, newItem: DisplayWallet): Boolean {
+        return oldItem == newItem
     }
-
 }

--- a/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletListFragment.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletListFragment.kt
@@ -26,7 +26,7 @@ import me.juangoncalves.mentra.ui.wallet_edit.EditWalletDialogFragment
 class WalletListFragment : Fragment(), WalletSwipeHelper.Listener {
 
     private val viewModel: WalletListViewModel by viewModels()
-    private val walletAdapter: WalletAdapter = WalletAdapter(emptyList())
+    private val walletAdapter: WalletAdapter = WalletAdapter()
 
     private var _binding: WalletListFragmentBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletListFragment.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletListFragment.kt
@@ -13,17 +13,16 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import me.juangoncalves.mentra.databinding.WalletListFragmentBinding
-import me.juangoncalves.mentra.extensions.createErrorSnackbar
-import me.juangoncalves.mentra.extensions.onDismissed
-import me.juangoncalves.mentra.extensions.showSnackbarOnFleetingErrors
-import me.juangoncalves.mentra.extensions.styleByTheme
+import me.juangoncalves.mentra.extensions.*
 import me.juangoncalves.mentra.ui.common.BundleKeys
 import me.juangoncalves.mentra.ui.common.RequestKeys
 import me.juangoncalves.mentra.ui.wallet_creation.WalletCreationActivity
 import me.juangoncalves.mentra.ui.wallet_deletion.DeleteWalletDialogFragment
 import me.juangoncalves.mentra.ui.wallet_edit.EditWalletDialogFragment
 
+@ExperimentalCoroutinesApi
 @AndroidEntryPoint
 class WalletListFragment : Fragment(), WalletSwipeHelper.Listener {
 
@@ -108,6 +107,10 @@ class WalletListFragment : Fragment(), WalletSwipeHelper.Listener {
             createErrorSnackbar(error, binding.addWalletButton)
                 .onDismissed { walletAdapter.notifyItemChanged(position) }
                 .show()
+        }
+
+        viewModel.shouldShowWalletLoadingIndicator.observe(viewLifecycleOwner) { shouldShow ->
+            binding.walletsLoadingIndicator.animateVisibility(shouldShow)
         }
     }
 

--- a/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletListFragment.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletListFragment.kt
@@ -1,5 +1,7 @@
 package me.juangoncalves.mentra.ui.wallet_list
 
+import android.animation.Animator
+import android.animation.AnimatorInflater
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -52,6 +54,25 @@ class WalletListFragment : Fragment(), WalletSwipeHelper.Listener {
         return binding.root
     }
 
+    /** Initialize the observers after the enter transition ended to prevent stuttering */
+    override fun onCreateAnimator(transit: Int, enter: Boolean, nextAnim: Int): Animator? {
+        val animator = AnimatorInflater.loadAnimator(activity, nextAnim)
+
+        val listener = object : Animator.AnimatorListener {
+            override fun onAnimationEnd(p0: Animator?) {
+                initObservers()
+                animator.removeListener(this)
+            }
+
+            override fun onAnimationStart(p0: Animator?) {}
+            override fun onAnimationCancel(p0: Animator?) {}
+            override fun onAnimationRepeat(p0: Animator?) {}
+        }
+
+        animator.addListener(listener)
+        return animator
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -70,8 +91,6 @@ class WalletListFragment : Fragment(), WalletSwipeHelper.Listener {
             val intent = Intent(requireContext(), WalletCreationActivity::class.java)
             startActivity(intent)
         }
-
-        initObservers()
     }
 
     private fun initObservers() {

--- a/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletListViewModel.kt
+++ b/app/src/main/java/me/juangoncalves/mentra/ui/wallet_list/WalletListViewModel.kt
@@ -4,7 +4,10 @@ import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.*
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
 import me.juangoncalves.mentra.di.DefaultDispatcher
 import me.juangoncalves.mentra.domain.models.Coin
@@ -28,15 +31,20 @@ class WalletListViewModel @ViewModelInject constructor(
     private val refreshPortfolioValue: RefreshPortfolioValue
 ) : ViewModel(), FleetingErrorPublisher by FleetingErrorPublisherImpl() {
 
+    @ExperimentalCoroutinesApi
     val wallets: LiveData<List<DisplayWallet>> = coinRepository.pricesOfCoinsInUse
+        .onStart { _shouldShowWalletLoadingIndicator.value = true }
+        .onEach { _shouldShowWalletLoadingIndicator.value = false }
         .combine(walletRepository.wallets, ::mergeIntoDisplayWallets)
         .asLiveData()
 
     val walletManagementError: LiveData<WalletManagementError> get() = _walletManagementError
     val shouldShowRefreshIndicator: LiveData<Boolean> get() = _shouldShowRefreshIndicator
+    val shouldShowWalletLoadingIndicator: LiveData<Boolean> get() = _shouldShowWalletLoadingIndicator
 
     private val _walletManagementError: MutableLiveData<WalletManagementError> = MutableLiveData()
     private val _shouldShowRefreshIndicator: MutableLiveData<Boolean> = MutableLiveData(false)
+    private val _shouldShowWalletLoadingIndicator: MutableLiveData<Boolean> = MutableLiveData(true)
 
 
     fun refreshSelected() {

--- a/app/src/main/res/layout/wallet_list_fragment.xml
+++ b/app/src/main/res/layout/wallet_list_fragment.xml
@@ -46,6 +46,16 @@
 
         </com.bosphere.fadingedgelayout.FadingEdgeLayout>
 
+        <ProgressBar
+            android:id="@+id/walletsLoadingIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminateTint="?attr/colorPrimary"
+            app:layout_constraintBottom_toTopOf="@+id/addWalletButton"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/fadingEdgeLayout" />
+
         <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
             android:id="@+id/addWalletButton"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Initialize the observers after the enter transition ends as displaying the list of wallet is an expensive operation that causes stuttering when combined with the enter animation.